### PR TITLE
fix: specialised object primitive

### DIFF
--- a/schemas/common/all-operators.json
+++ b/schemas/common/all-operators.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "http://jsonlogic.com/schemas/common/all-operators.json",
+
+  "title": "All Operators",
+  "description": "Any valid JSON Logic data source, expect primitive types.",
+
+  "oneOf": [
+    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/variable.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/missing.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/missing_some.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/add.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/divide.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/modulo.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/multiply.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/substract.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/all.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/filter.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/map.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/merge.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/none.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/reduce.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/some.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/and.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/equal.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/if.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/not.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/notEqual.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/notnot.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/or.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/strictEqual.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/strictNotEqual.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/misc/in.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/misc/log.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/misc/method.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/greater.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/greaterEqual.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/less.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/lessEqual.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/max.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/min.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/string/cat.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/string/substr.json" }
+  ]
+}

--- a/schemas/common/all-types-wo-array.json
+++ b/schemas/common/all-types-wo-array.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "http://jsonlogic.com/schemas/common/all-types-wo-array.json",
+
+  "title": "All",
+  "description": "Any valid JSON data type.",
+
+  "oneOf": [
+    { "type": ["boolean", "null", "number", "string"] },
+    {
+      "type": "object",
+      "minProperties": 2
+    }
+  ]
+}

--- a/schemas/common/all-types-wo-array.json
+++ b/schemas/common/all-types-wo-array.json
@@ -3,7 +3,7 @@
   "$id": "http://jsonlogic.com/schemas/common/all-types-wo-array.json",
 
   "title": "All",
-  "description": "Any valid JSON data type.",
+  "description": "Any valid JSON data type, except array primitive.",
 
   "oneOf": [
     { "type": ["boolean", "null", "number", "string"] },

--- a/schemas/common/all-types-wo-array.json
+++ b/schemas/common/all-types-wo-array.json
@@ -7,9 +7,6 @@
 
   "oneOf": [
     { "type": ["boolean", "null", "number", "string"] },
-    {
-      "type": "object",
-      "minProperties": 2
-    }
+    { "$ref": "http://jsonlogic.com/schemas/common/no-logic-object.json" }
   ]
 }

--- a/schemas/common/all-types.json
+++ b/schemas/common/all-types.json
@@ -7,9 +7,6 @@
 
   "oneOf": [
     { "type": ["boolean", "null", "number", "string", "array"] },
-    {
-      "type": "object",
-      "minProperties": 2
-    }
+    { "$ref": "http://jsonlogic.com/schemas/common/no-logic-object.json" }
   ]
 }

--- a/schemas/common/all-types.json
+++ b/schemas/common/all-types.json
@@ -12,7 +12,7 @@
       "minProperties": 1,
       "maxProperties": 1,
       "patternProperties": {
-        "^((?!(var|missing|missing_some|+|/|%|*|-|all|filter|map|merge|none|reduce|some|and|==|if|!|!=|!!|or|===|!===|in|log|method|>|>=|<|<=|max|min|cat|substr)).)*$": {}
+        "^((?!(var|missing|missing_some|\\+|\\/|%|\\*|-|all|filter|map|merge|none|reduce|some|and|==|if|!|!=|!!|or|===|!===|in|log|method|>|>=|<|<=|max|min|cat|substr)).)*$": {}
       }
     },
     {

--- a/schemas/common/all-types.json
+++ b/schemas/common/all-types.json
@@ -4,5 +4,20 @@
 
   "title": "All",
   "description": "Any valid JSON data type.",
-  "type": ["array", "boolean", "null", "number", "object", "string"]
+
+  "oneOf": [
+    { "type": ["array", "boolean", "null", "number", "string"] },
+    {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "patternProperties": {
+        "^((?!(var|missing|missing_some|+|/|%|*|-|all|filter|map|merge|none|reduce|some|and|==|if|!|!=|!!|or|===|!===|in|log|method|>|>=|<|<=|max|min|cat|substr)).)*$": {}
+      }
+    },
+    {
+      "type": "object",
+      "minProperties": 2
+    }
+  ]
 }

--- a/schemas/common/all-types.json
+++ b/schemas/common/all-types.json
@@ -6,15 +6,7 @@
   "description": "Any valid JSON data type.",
 
   "oneOf": [
-    { "type": ["array", "boolean", "null", "number", "string"] },
-    {
-      "type": "object",
-      "minProperties": 1,
-      "maxProperties": 1,
-      "patternProperties": {
-        "^((?!(var|missing|missing_some|\\+|\\/|%|\\*|-|all|filter|map|merge|none|reduce|some|and|==|if|!|!=|!!|or|===|!===|in|log|method|>|>=|<|<=|max|min|cat|substr)).)*$": {}
-      }
-    },
+    { "type": ["boolean", "null", "number", "string", "array"] },
     {
       "type": "object",
       "minProperties": 2

--- a/schemas/common/any-wo-array.json
+++ b/schemas/common/any-wo-array.json
@@ -6,47 +6,7 @@
   "description": "Any valid JSON Logic data source, except array primitive.",
 
   "oneOf": [
-    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/variable.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/missing.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/missing_some.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/add.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/divide.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/modulo.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/multiply.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/substract.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/all.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/filter.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/map.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/merge.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/none.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/reduce.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/some.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/and.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/equal.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/if.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/not.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/notEqual.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/notnot.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/or.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/strictEqual.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/strictNotEqual.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/misc/in.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/misc/log.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/misc/method.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/greater.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/greaterEqual.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/less.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/lessEqual.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/max.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/min.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/string/cat.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/string/substr.json" },
+    { "$ref": "http://jsonlogic.com/schemas/common/all-operators.json" },
 
     { "$ref": "http://jsonlogic.com/schemas/common/all-types-wo-array.json" }
   ]

--- a/schemas/common/any-wo-array.json
+++ b/schemas/common/any-wo-array.json
@@ -3,7 +3,7 @@
   "$id": "http://jsonlogic.com/schemas/common/any-wo-array.json",
 
   "title": "All",
-  "description": "Any valid JSON Logic data source.",
+  "description": "Any valid JSON Logic data source, except array primitive.",
 
   "oneOf": [
     { "$ref": "http://jsonlogic.com/schemas/operators/accessor/variable.json" },

--- a/schemas/common/any-wo-array.json
+++ b/schemas/common/any-wo-array.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "http://jsonlogic.com/schemas/common/any-wo-array.json",
+
+  "title": "All",
+  "description": "Any valid JSON Logic data source.",
+
+  "oneOf": [
+    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/variable.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/missing.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/missing_some.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/add.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/divide.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/modulo.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/multiply.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/substract.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/all.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/filter.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/map.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/merge.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/none.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/reduce.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/some.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/and.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/equal.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/if.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/not.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/notEqual.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/notnot.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/or.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/strictEqual.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/logic/strictNotEqual.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/misc/in.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/misc/log.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/misc/method.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/greater.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/greaterEqual.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/less.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/lessEqual.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/max.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/min.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/operators/string/cat.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/string/substr.json" },
+
+    { "$ref": "http://jsonlogic.com/schemas/common/all-types-wo-array.json" }
+  ]
+}

--- a/schemas/common/any.json
+++ b/schemas/common/any.json
@@ -6,47 +6,7 @@
   "description": "Any valid JSON Logic data source.",
 
   "oneOf": [
-    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/variable.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/missing.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/accessor/missing_some.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/add.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/divide.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/modulo.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/multiply.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/arithmetic/substract.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/all.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/filter.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/map.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/merge.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/none.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/reduce.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/array/some.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/and.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/equal.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/if.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/not.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/notEqual.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/notnot.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/or.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/strictEqual.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/logic/strictNotEqual.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/misc/in.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/misc/log.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/misc/method.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/greater.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/greaterEqual.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/less.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/lessEqual.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/max.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/numeric/min.json" },
-
-    { "$ref": "http://jsonlogic.com/schemas/operators/string/cat.json" },
-    { "$ref": "http://jsonlogic.com/schemas/operators/string/substr.json" },
+    { "$ref": "http://jsonlogic.com/schemas/common/all-operators.json" },
 
     { "$ref": "http://jsonlogic.com/schemas/common/all-types.json" }
   ]

--- a/schemas/common/any.json
+++ b/schemas/common/any.json
@@ -5,7 +5,7 @@
   "title": "All",
   "description": "Any valid JSON Logic data source.",
 
-  "anyOf": [
+  "oneOf": [
     { "$ref": "http://jsonlogic.com/schemas/operators/accessor/variable.json" },
     { "$ref": "http://jsonlogic.com/schemas/operators/accessor/missing.json" },
     { "$ref": "http://jsonlogic.com/schemas/operators/accessor/missing_some.json" },

--- a/schemas/common/binary-args.json
+++ b/schemas/common/binary-args.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "$ref": "http://jsonlogic.com/schemas/common/any.json",
+      "$ref": "http://jsonlogic.com/schemas/common/any-wo-array.json",
       "title": "Single Arg",
       "description": "Note: binary operators can also take a single, non array argument:"
     }

--- a/schemas/common/no-logic-object.json
+++ b/schemas/common/no-logic-object.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "http://jsonlogic.com/schemas/common/no-logic-object.json",
+
+  "title": "No-Logic",
+  "description": "Any valid JSON object which is not a logic rule.",
+
+  "oneOf": [
+    {
+      "title": "Empty object.",
+      "type": "object",
+      "maxProperties": 0
+    },
+    {
+      "title": "Non-Logic single key object.",
+      "allOf": [
+        {
+          "type": "object",
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        {
+          "not": {
+            "type": "object",
+            "minProperties": 1,
+            "maxProperties": 1,
+            "oneOf": [
+              { "required": ["var"] },
+              { "required": ["missing"] },
+              { "required": ["missing_some"] },
+              { "required": ["+"] },
+              { "required": ["/"] },
+              { "required": ["%"] },
+              { "required": ["*"] },
+              { "required": ["-"] },
+              { "required": ["all"] },
+              { "required": ["filter"] },
+              { "required": ["map"] },
+              { "required": ["merge"] },
+              { "required": ["none"] },
+              { "required": ["reduce"] },
+              { "required": ["some"] },
+              { "required": ["and"] },
+              { "required": ["=="] },
+              { "required": ["if"] },
+              { "required": ["?:"] },
+              { "required": ["!"] },
+              { "required": ["!="] },
+              { "required": ["!!"] },
+              { "required": ["or"] },
+              { "required": ["==="] },
+              { "required": ["!=="] },
+              { "required": ["in"] },
+              { "required": ["log"] },
+              { "required": ["method"] },
+              { "required": [">"] },
+              { "required": [">="] },
+              { "required": ["<"] },
+              { "required": ["<="] },
+              { "required": ["max"] },
+              { "required": ["min"] },
+              { "required": ["cat"] },
+              { "required": ["substr"] }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "title": "Non-Logic multiple key object.",
+      "type": "object",
+      "minProperties": 2
+    }
+  ]
+}

--- a/schemas/common/one-or-more-args.json
+++ b/schemas/common/one-or-more-args.json
@@ -10,13 +10,12 @@
       "title": "Single Array",
       "description": "An array with 1 or more elements.",
       "type": "array",
-      "minItems": 1,
       "items": {
         "$ref": "http://jsonlogic.com/schemas/common/any.json"
       }
     },
     {
-      "$ref": "http://jsonlogic.com/schemas/common/any.json",
+      "$ref": "http://jsonlogic.com/schemas/common/any-wo-array.json",
       "title": "Single Arg",
       "description": "Note: 1 or more operators can also take a single, non array argument:"
     }

--- a/schemas/common/pointer.json
+++ b/schemas/common/pointer.json
@@ -9,12 +9,14 @@
     {
       "type": "string",
       "title": "Property",
-      "description": "The key passed to var can use dot-notation to get the property of a property (to any depth you need):"
+      "description": "The key passed to var can use dot-notation to get the property of a property (to any depth you need):",
+      "minLength": 1
     },
     {
-      "type": "number",
+      "type": "integer",
       "title": "Index",
-      "description": "You can also use the var operator to access an array by numeric index."
+      "description": "You can also use the var operator to access an array by numeric index.",
+      "minimum": 0
     }
   ]
 }

--- a/schemas/common/trinary-args.json
+++ b/schemas/common/trinary-args.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "$ref": "http://jsonlogic.com/schemas/common/any.json",
+      "$ref": "http://jsonlogic.com/schemas/common/any-wo-array.json",
       "title": "Single Arg",
       "description": "Note: trinary operators can also take a single, non array argument:"
     }

--- a/schemas/common/unary-arg.json
+++ b/schemas/common/unary-arg.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "$ref": "http://jsonlogic.com/schemas/common/any.json",
+      "$ref": "http://jsonlogic.com/schemas/common/any-wo-array.json",
       "title": "Single Arg",
       "description": "Note: unary operators can also take a single, non array argument:"
     }

--- a/schemas/common/var.json
+++ b/schemas/common/var.json
@@ -9,7 +9,12 @@
     {
       "type": "array",
       "items": [
-        { "$ref": "http://jsonlogic.com/schemas/common/pointer.json" },
+        {
+          "oneOf": [
+            { "$ref": "http://jsonlogic.com/schemas/common/pointer.json" },
+            { "$ref": "http://jsonlogic.com/schemas/operators/logic/if.json" }
+          ]
+        },
         {
           "$ref": "http://jsonlogic.com/schemas/common/all-types.json",
           "title": "Default",
@@ -17,6 +22,10 @@
         }
       ]
     },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/map.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/merge.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/filter.json" },
+    { "$ref": "http://jsonlogic.com/schemas/operators/array/reduce.json" },
     {
       "$ref": "http://jsonlogic.com/schemas/common/pointer.json",
       "title": "Shortcut",
@@ -27,6 +36,11 @@
       "enum": [""],
       "title": "Entire data object",
       "description": "You can also use var with an empty string to get the entire data object – which is really useful in map, filter, and reduce rules."
+    },
+    {
+      "type": "null",
+      "title": "Null",
+      "description": "Unknown null."
     }
   ]
 }

--- a/schemas/operators/logic/if.json
+++ b/schemas/operators/logic/if.json
@@ -4,12 +4,27 @@
 
   "title": "if",
   "description": "The if statement typically takes 3 arguments: a condition (if), what to do if it’s true (then), and what to do if it’s false (else), like: {\"if\" : [ true, \"yes\", \"no\" ]}.\nIf can also take more than 3 arguments, and will pair up arguments like if/then elseif/then elseif/then else.",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["if"],
-  "properties": {
-    "if": {
-      "$ref": "http://jsonlogic.com/schemas/common/one-or-more-args.json"
+
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["if"],
+      "properties": {
+        "if": {
+          "$ref": "http://jsonlogic.com/schemas/common/one-or-more-args.json"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["?:"],
+      "properties": {
+        "?:": {
+          "$ref": "http://jsonlogic.com/schemas/common/one-or-more-args.json"
+        }
+      }
     }
-  }
+  ]
 }

--- a/schemas/operators/string/cat.json
+++ b/schemas/operators/string/cat.json
@@ -9,7 +9,7 @@
   "required": ["cat"],
   "properties": {
     "cat": {
-      "$ref": "http://jsonlogic.com/schemas/common/any.json"
+      "$ref": "http://jsonlogic.com/schemas/common/one-or-more-args.json"
     }
   }
 }

--- a/schemas/operators/string/substr.json
+++ b/schemas/operators/string/substr.json
@@ -9,7 +9,7 @@
   "required": ["substr"],
   "properties": {
     "substr": {
-      "$ref": "http://jsonlogic.com/schemas/common/any.json"
+      "$ref": "http://jsonlogic.com/schemas/common/trinary-args.json"
     }
   }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -100,7 +100,7 @@ remote_or_cache(
       )}) === ${JSON.stringify(expected)}`
     );
 
-    assert.equal(validate(rule), true, JSON.stringify(rule) + JSON.stringify(validate.errors, null, 2));
+    assert.equal(validate(rule), true, JSON.stringify(rule) + '\n\n' + JSON.stringify(validate.errors, null, 2));
   }
 );
 


### PR DESCRIPTION
fixes #15 

**Changes:**

- [x] removes `array` type for single arg checks
- [x] replaces `anyOf` with `oneOf`
- [x] only allow `object` type, if object is empty, has more than 2 keys, or single key does not match existing operator name
- [x] adds `?:` alias for `if`