### PR TITLE
docs: moved git hooks below CI/CD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ install:
 script:
   - npm run lint
   - npm run lint:schemas
+  - npm run test
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - '10.15.1'
+cache:
+  directories:
+    - ".eslintcache"
+    - "node_modules"
+install:
+  - npm install
+script:
+  - npm run lint
+  - npm run lint:schemas
+  - npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,9 @@
 - [Styleguides](#styleguides)
   - [JavaScript](#javascript)
   - [Git Commit Messages](#git-commit-messages)
-  - [Git Hooks](#git-hooks)
   - [Editors](#editors)
+- [CI/CD](#cicd)
+  - [Git Hooks](#git-hooks)
 - [Releasing a new version](#releasing-a-new-version)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -84,13 +85,15 @@ This project utilizes [`commitlint`](https://commitlint.js.org/) to enforce [**C
 
 These rules form the basis for our [`CHANGELOG.md`](./CHANGELOG.md) and automatic versioning of releases.
 
-## Git Hooks
-
-We use [`husky`](https://github.com/typicode/husky#readme) and [`lintstaged`](https://github.com/okonet/lint-staged#readme) to enforce those styleguide rules for each commit.
-
 ## Editors
 
 Basic configuration for various editors is provided by an [`editorconfig`](https://editorconfig.org/) file.
+
+# CI/CD
+
+## Git Hooks
+
+We use [`husky`](https://github.com/typicode/husky#readme) and [`lintstaged`](https://github.com/okonet/lint-staged#readme) to enforce those styleguide rules for each commit.
 
 # Releasing a new version
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@
   - [Editors](#editors)
 - [CI/CD](#cicd)
   - [Git Hooks](#git-hooks)
+  - [Travis](#travis)
 - [Releasing a new version](#releasing-a-new-version)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -94,6 +95,10 @@ Basic configuration for various editors is provided by an [`editorconfig`](https
 ## Git Hooks
 
 We use [`husky`](https://github.com/typicode/husky#readme) and [`lintstaged`](https://github.com/okonet/lint-staged#readme) to enforce those styleguide rules for each commit.
+
+## Travis
+
+[**Travis CI**](https://travis-ci.org/) is configured to lint source files, run all tests and run a build to check pull requests.
 
 # Releasing a new version
 


### PR DESCRIPTION
I moved the git hooks part below CI/CD

**Note:** ~~We should~~ add Travis 🤔 